### PR TITLE
Uno 23 create card class that represents a single uno card

### DIFF
--- a/model/card.py
+++ b/model/card.py
@@ -1,9 +1,10 @@
 import pygame
 import pygwidgets
+import os
 
 class Card():
     
-    BACK_OF_CARD = pygame.image.load('..images/card_back_alt.png')
+    BACK_OF_CARD = pygame.image.load('./images/card_back_alt.png')
     
     def __init__(self, window, color, value, file_name=None):
         self.window = window

--- a/model/card.py
+++ b/model/card.py
@@ -1,0 +1,44 @@
+import pygame
+import pygwidgets
+
+class Card():
+    
+    BACK_OF_CARD = pygame.image.load('..images/card_back_alt.png')
+    
+    def __init__(self, window, color, value, file_name=None):
+        self.window = window
+        self.color = color
+        self.value = value
+        self.card_name = color + '_' + value
+        
+        if file_name is None:
+            file_name + '..images/' + self.card_name + '.png'
+            
+        self.images = pygwidgets.ImageCollection(window, (0,0), 
+                                                 {'front': file_name,
+                                                  'back': Card.BACK_OF_CARD},'back')
+    
+    def conceal(self):
+        self.images.replace('back')
+        
+    def reveal(self):
+        self.images.replace('front')
+        
+    def get_color(self):
+        return self.color
+    
+    def get_value(self):
+        return self.value
+    
+    def get_name(self):
+        return self.card_name
+    
+    def get_location(self):
+        return self.images.getLoc()
+    
+    def set_location(self, location):
+        self.images.setLoc(location)
+    
+    def draw(self):
+        # renders card
+        self.images.draw()

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import Mock
+import pygame
+import pygwidgets
+from ..model import Card 
+
+class TestCard(unittest.TestCase):
+
+    def setUp(self):
+        # Mock the pygame window and ImageCollection
+        self.mock_window = Mock()
+        self.mock_image_collection = Mock()
+        pygwidgets.ImageCollection = Mock(return_value=self.mock_image_collection)
+        
+        self.card = Card(self.mock_window, 'red', '5', 'test_file_name.png')
+
+    def test_initialization(self):
+        self.assertEqual(self.card.color, 'red')
+        self.assertEqual(self.card.value, '5')
+        self.assertEqual(self.card.card_name, 'red_5')
+        # Test that the ImageCollection was initialized with the correct parameters
+        pygwidgets.ImageCollection.assert_called_with(self.mock_window, (0, 0), {'front': 'test_file_name.png', 'back': Card.BACK_OF_CARD}, 'back')
+
+    def test_conceal_reveal(self):
+        self.card.conceal()
+        self.mock_image_collection.replace.assert_called_with('back')
+
+        self.card.reveal()
+        self.mock_image_collection.replace.assert_called_with('front')
+
+    def test_getters(self):
+        self.assertEqual(self.card.get_color(), 'red')
+        self.assertEqual(self.card.get_value(), '5')
+        self.assertEqual(self.card.get_name(), 'red_5')
+
+    def test_location(self):
+        # Set a new location and verify it is updated
+        new_location = (100, 200)
+        self.card.set_location(new_location)
+        self.mock_image_collection.setLoc.assert_called_with(new_location)
+
+        # Mock the getLoc method to return the new location
+        self.mock_image_collection.getLoc.return_value = new_location
+        self.assertEqual(self.card.get_location(), new_location)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -2,7 +2,12 @@ import unittest
 from unittest.mock import Mock
 import pygame
 import pygwidgets
-from ..model import Card 
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from model.card import Card
+
+
 
 class TestCard(unittest.TestCase):
 


### PR DESCRIPTION
From root directory run :

`python -m unittest discover -s tests -v`

expected output:
pygame-ce 2.4.1 (SDL 2.28.5, Python 3.11.6)
test_conceal_reveal (test_card.TestCard.test_conceal_reveal) ... ok
test_getters (test_card.TestCard.test_getters) ... ok
test_initialization (test_card.TestCard.test_initialization) ... ok
test_location (test_card.TestCard.test_location) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.002s

OK