### PR TITLE
Uno 79 force player to draw a card when they have no matching cards

### DIFF
--- a/model/game_net.py
+++ b/model/game_net.py
@@ -115,9 +115,9 @@ class Game():
         if len(self.discard_pile) == 0:
             print("No card in play yet")
             return True
-        for i in range(len(player.hand)):
-            if player.check_conditions(player.hand[i],self.current_color, self.current_value):
-                return True
-            
-        return False
-    
+        else:
+            for card in player.hand:
+                if player.check_conditions(card, self.current_color, self.current_value):
+                    return True
+
+            return False

--- a/model/game_net.py
+++ b/model/game_net.py
@@ -23,16 +23,6 @@ class Game():
     def check_direction(self):
         return self.current_direction
     
-    def check_hand(self, player):
-        if len(self.discard_pile) == 0:
-            print("No card in play yet")
-            return True
-        for i in range(len(player.hand)):
-            if player.check_conditions(player.hand[i],self.current_color, self.current_value):
-                return True
-            
-        return False
-    
     def condition_to_dict(self):
         return f"{self.current_color},{self.current_value}"
     
@@ -121,4 +111,13 @@ class Game():
         conditions = {"current_color": self.current_color, "current_value": self.current_value}
         return json.dumps(conditions, indent=4)
     
+    def check_hand(self, player):
+        if len(self.discard_pile) == 0:
+            print("No card in play yet")
+            return True
+        for i in range(len(player.hand)):
+            if player.check_conditions(player.hand[i],self.current_color, self.current_value):
+                return True
+            
+        return False
     

--- a/server.py
+++ b/server.py
@@ -183,7 +183,16 @@ class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
             message = "current_player$" + current_player + "\n"
             print(f"Current player: {current_player}")
             for client in self.clients:
-                client.send(message.encode()) 
+                client.send(message.encode())
+            if self.game.check_hand(self.game.get_current_player()):
+                self.send_draw_card(self.game.current_player_index)
+                # function to draw card 
+            
+
+    # send draw_card$
+    def send_draw_card(self, index):
+        message = "draw_card$\n"
+        self.clients[index].send(message.encode())
 
     def initialize_game(self):
         for player in self.game.players:

--- a/view/multiplayer_game_board.py
+++ b/view/multiplayer_game_board.py
@@ -125,7 +125,8 @@ class MultiplayerGameBoard(pyghelpers.Scene):
             print("host_status message received")
             self.host_status = message.split('$')[1] == "yes"
             print(self.host_status)
-
+        elif message.startswith("draw_card$"):
+            pass
         elif message.startswith("current_player$"):
             current_player_id = message.split('$')[1]
             current_player = json.loads(current_player_id)

--- a/view/multiplayer_game_board.py
+++ b/view/multiplayer_game_board.py
@@ -66,10 +66,13 @@ class MultiplayerGameBoard(pyghelpers.Scene):
         self.host_status = False
         self.game_started = False
         self.is_current_player = False
+        self.must_draw = False
         self.discard_pile = []
         self.bg_color = (255, 255, 255)
         self.current_color = ""
         self.current_value = ""
+
+        self.draw_card_button = pygwidgets.TextButton(window, (100, 300), "Draw Card", width=100, height=50)
 
     def enter(self, data):
         self.client_name = data.get('player_name')
@@ -86,7 +89,7 @@ class MultiplayerGameBoard(pyghelpers.Scene):
             self.process_message(message)
 
     def process_message(self, message):
-        #print(f"Processing message: {message}")
+        print(f"Processing message: {message}")
         if message.startswith("start_game$"):
             print("Game started")
             self.game_started = True
@@ -126,7 +129,10 @@ class MultiplayerGameBoard(pyghelpers.Scene):
             self.host_status = message.split('$')[1] == "yes"
             print(self.host_status)
         elif message.startswith("draw_card$"):
-            pass
+            print("Must draw card")
+            if len(self.discard_pile) != 0:
+                self.must_draw = True
+            
         elif message.startswith("current_player$"):
             current_player_id = message.split('$')[1]
             current_player = json.loads(current_player_id)
@@ -134,6 +140,8 @@ class MultiplayerGameBoard(pyghelpers.Scene):
                 self.is_current_player = True
             else:
                 self.is_current_player = False
+        
+            
 
     def handleInputs(self, events, keyPressedList):
         for event in events:
@@ -146,6 +154,10 @@ class MultiplayerGameBoard(pyghelpers.Scene):
                             self.game_client.send_message(f"play_card${card.to_json()}\n")            
                         else:
                             print("Invalid card played")
+                    elif self.must_draw:
+                        if self.draw_card_button.handleEvent(event):
+                            self.game_client.send_message("draw_card$")
+                            self.must_draw = False
 
     def draw(self):
         # Clear the screen first
@@ -167,6 +179,9 @@ class MultiplayerGameBoard(pyghelpers.Scene):
         if len(self.discard_pile) != 0 and self.discard_pile[0] is not None:
             #sprint(f"Discard pile {self.discard_pile[0].card}")
             self.discard_pile[0].draw()
+        
+        if self.must_draw and len(self.discard_pile) != 0:
+            self.draw_card_button.draw()
 
 
     def check_conditions(self, card, color, value):


### PR DESCRIPTION
To successfully set up this environment, you'll need to have three terminals running concurrently. Ensure your virtual environment (venv) is activated in each terminal before proceeding with the following steps:
Terminal 1: Setting up the Server

1. Execute the command `python server.py` to initiate the server.

Terminal 2: Launching the First Client

1. In the new terminal, run `python scene_manager.py` to start the scene manager.
2. Choose the "Multiplayer" option when prompted.
3. Enter a unique name for your session and click within the window area, then press "Play."
4. The resulting window should display a play button 

Terminal 3: Adding Another Client

1. Repeat the steps you followed in Terminal 2, but make sure to use a different name this time.

Terminal 2 & 3
1. Press Play button on terminal 2
2. verify both client windows have a unique hand (different from each other)
3. go in between the clients and verify that a draw button appears when the client can't play a card
4. Press the draw button and verify that: 

- A card was added to the client's hand.
- the opponent view updated in the other client's window
- their turn ended and the next person can play 